### PR TITLE
Add JSON repoter to support to read the command line output to reuse

### DIFF
--- a/src/reporters/Json.js
+++ b/src/reporters/Json.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const BaseReporter = require('./BaseReporter');
+const { formatSize } = require('./helpers');
+
+class Json extends BaseReporter {
+  /**
+   * @param {Dependency} dependency
+   */
+  print(dependency) {
+    if (dependency.isReal()) {
+      this.options.printer(JSON.stringify(this.draw(dependency)));
+      return;
+    }
+
+    dependency.children.forEach((dep) => {
+      this.options.printer(JSON.stringify(this.draw(dep)));
+    });
+  }
+
+  /**
+   * @param {Dependency} dependency
+   * @param {Object} deps
+   * @private
+   */
+  draw(dependency, deps = {}) {
+    const stats = dependency.getStatsRecursive();
+    const dependencies = dependency.children;
+    const label = dependency.getLabel();
+
+    deps[dependency.toString()] = {
+      deps: stats.dependencyCount,
+      size: formatSize(stats.unpackedSize),
+      fileCount: stats.fileCount,
+    };
+
+    if (label) {
+      if (label === 'duplicate') {
+        deps[dependency.toString()].duplicate = true;
+      } else if (label === 'unmet') {
+        deps[dependency.toString()].unmet = 'UNMET';
+      }
+    }
+
+    if (dependencies.length) {
+      dependencies.forEach((dep) => {
+        deps[dependency.toString()][dep.toString()] = {
+          deps: stats.dependencyCount,
+          size: formatSize(stats.unpackedSize),
+          fileCount: stats.fileCount,
+        };
+
+        this.draw(dep, deps[dependency.toString()]);
+      });
+    }
+
+    return deps;
+  }
+}
+
+module.exports = Json;

--- a/src/reporters/__specs__/Json.spec.js
+++ b/src/reporters/__specs__/Json.spec.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { describe, expect, it } = require('humile');
+const Json = require('../Json');
+const { loadFixture } = require('../../__specs__');
+
+describe('reporters/Json', () => {
+  it('should print a complete json', async () => {
+    const graph = await loadFixture('npm-package-arg');
+
+    const jsonOutput = [];
+
+    const json = new Json({
+      printer: (text) => jsonOutput.push(text),
+    });
+    json.print(graph.getRoot());
+
+    expect(jsonOutput[0]).toEqual('{"npm-package-arg@6.1.1":{"deps":7,"size":'
+      + '"132.23kb","fileCount":47,"hosted-git-info@2.8.5":{"deps":0,'
+      + '"size":"22.73kb","fileCount":7},"osenv@0.1.5":{"deps":2,'
+      + '"size":"10.84kb","fileCount":12,"os-homedir@1.0.2":{"deps":0,'
+      + '"size":"3.08kb","fileCount":4},"os-tmpdir@1.0.2":{"deps":0,'
+      + '"size":"2.98kb","fileCount":4}},"semver@5.7.1":{"deps":0,'
+      + '"size":"60.13kb","fileCount":7},"validate-npm-package-name@3.0.0":{'
+      + '"deps":1,"size":"23.14kb","fileCount":16,"builtins@1.0.3":{"deps":0,'
+      + '"size":"2.63kb","fileCount":7}}}}');
+  });
+});

--- a/src/reporters/index.js
+++ b/src/reporters/index.js
@@ -3,6 +3,7 @@
 const Simple = require('./Simple');
 const Table = require('./Table');
 const Tree = require('./Tree');
+const Json = require('./Json');
 
 module.exports = {
   createReporter,
@@ -17,6 +18,7 @@ function createReporter(options = {}) {
   options = { printer: console.info, ...options };
 
   switch (options.name) {
+    case 'json': return new Json(options);
     case 'simple': return new Simple(options);
     case 'table': return new Table(options);
     default: return new Tree(options);


### PR DESCRIPTION
in any other application.

My use case is I want to add a graph of dependencies in a NetBeans plugin and I found your nice package. So I will use java to parse the json line and use it in my application. Maybe there is a need to rewrite the formatStats function because I want to use the extra information (filecount, deps, etc.) for different use cases.